### PR TITLE
Remove functions coverage

### DIFF
--- a/Week3/README.md
+++ b/Week3/README.md
@@ -4,7 +4,7 @@
 In week four we will discuss the following topics:
 • JSON
 • Code debugging using the browser
-• Functions + JSON/Arrays
+• JSON/Arrays
 • Code flow (order of execution)
 • (capturing user input)
 • Structuring code files


### PR DESCRIPTION
We could remove `functions` from teaching material since it is already covered in Week 2.